### PR TITLE
Point App insights to the LAW

### DIFF
--- a/terraform/team/appinsights.tf
+++ b/terraform/team/appinsights.tf
@@ -4,6 +4,7 @@ resource "azurerm_application_insights" "aksainsights" {
   application_type    = "Node.JS"
   location            = azurerm_resource_group.aksrg.location
   resource_group_name = azurerm_resource_group.aksrg.name
+  workspace_id        = azurerm_log_analytics_workspace.akslogs.id
 
   tags = {
     environment = var.deployment_name


### PR DESCRIPTION
New regions are not supporting the App Insights classic mode, so they need to be connected to a log analytics. As we have one already, let's use it, so we make our life easier. 

