### PR TITLE
Updated kubernetes_version_prefix to 1.26

### DIFF
--- a/terraform/team/variables.tf
+++ b/terraform/team/variables.tf
@@ -31,7 +31,7 @@ variable "vm_size" {
 # kubernetes version
 variable "kubernetes_version_prefix" {
   type        = string
-  default     = "1.22"
+  default     = "1.26"
   description = "The Kubernetes Version prefix (MAJOR.MINOR) to be used by the AKS cluster. The BUGFIX version is determined automatically (latest)."
 }
 


### PR DESCRIPTION
Updated `kubernetes_version_prefix` to 1.26 to choose the latest supported Kubernetes version in AKS